### PR TITLE
Updated StreetSmart to check for Cefpython3 installation

### DIFF
--- a/street_smart.py
+++ b/street_smart.py
@@ -234,26 +234,27 @@ class ButtonStateSubject(QObject):
 
 
         #TODO refactor checks if the required DLLS are available if not copies them from the Bin dir to the DLLS dir
-        if not check_DLLS()[0]:
-            files = ['libssl-1_1-x64.dll', 'libcrypto-1_1-x64.dll']
-            checkbox_dialog = CheckboxDialog(files)
-            result = checkbox_dialog.exec_()
-            # Get the selected files if the OK button is clicked
-            print("returned files",check_DLLS()[1])
-            
-            if result == QDialog.Accepted:
-                #selected_files = checkbox_dialog.selected_files
-                print("Selected files:", files)
-                for files in files:
-                    print(files)
-                    copy_missen_DLLS(os.path.join(return_Qgis_bin_path(check_DLLS()[1]),files),os.path.join(check_DLLS()[1],files))
-            else:
-                print("Dialog canceled")
-
-
-        #TODO check if Cefpython3 is not installed and install it
         if not check_Cefpython_installation():
-            install_cefpython3()
+            if not check_DLLS()[0]:
+                files = ['libssl-1_1-x64.dll', 'libcrypto-1_1-x64.dll']
+                checkbox_dialog = CheckboxDialog(files)
+                result = checkbox_dialog.exec_()
+                # Get the selected files if the OK button is clicked
+                print("returned files",check_DLLS()[1])
+                
+                if result == QDialog.Accepted:
+                    #selected_files = checkbox_dialog.selected_files
+                    print("Selected files:", files)
+                    for files in files:
+                        print(files)
+                        copy_missen_DLLS(os.path.join(return_Qgis_bin_path(check_DLLS()[1]),files),os.path.join(check_DLLS()[1],files))
+                else:
+                    print("Dialog canceled")
+
+
+            #TODO check if Cefpython3 is not installed and install it
+            if not check_Cefpython_installation():
+                install_cefpython3()
 
 
 


### PR DESCRIPTION
Updated StreetSmart to check for Cefpython3 installation before displaying the dialog to copy the needed DLLS, so that ones Cefpython3 is installed in the app directory it could persist for all Qgis installations, no need to copy any specifc DLLS, if not any new Qgis installation will require its own DLL copy which is not necessary